### PR TITLE
Use error codes to determine if next mirror is required

### DIFF
--- a/pirate-get.py
+++ b/pirate-get.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import webbrowser
 import urllib
-import urllib2
+import requests
 import re
 import os
 from HTMLParser import HTMLParser
@@ -67,8 +67,7 @@ def main():
         # Catch the Ctrl-C exception and exit cleanly
         try:
             for page in xrange(pages):
-                f = urllib2.urlopen(mirror + '/search/' + args.q.replace(" ", "+") + '/' + str(page) + '/7/0')
-                res = f.read()
+                res = requests.get(mirror + '/search/' + args.q.replace(" ", "+") + '/' + str(page) + '/7/0').text
                 found = re.findall(""""(magnet\:\?xt=[^"]*)|<td align="right">([^<]+)</td>""", res)
 
                 # get sizes as well and substitute the &nbsp; character
@@ -102,16 +101,18 @@ def main():
     if args.database:
         mags = local(args)
     else:
-        mirrors = ["http://thepiratebay.se"]
+        mirrors = ["http://thepiratebay.se/"]
         try:
-            f = urllib2.urlopen("http://proxybay.info/list.txt")
-            res = f.read()
+            res = requests.get("http://proxybay.info/list.txt").text
             mirrors += res.split("\n")[3:]
         except:
             print "Could not fetch additional mirrors"
         for mirror in mirrors:
             try:
                 print("Trying " + mirror)
+                code = requests.head(mirror).status_code
+                if code != 200:
+                  continue
                 mags, sizes, uploaded = remote(args, mirror)
                 break
             except Exception, e:


### PR DESCRIPTION
Moved from urllib2 to requests module in order to deal with head requests properly 
Augments 951fc1a in fixing #5
