### PR TITLE
Fixed issue #36 wrong url for proxy list

### DIFF
--- a/pirate-get.py
+++ b/pirate-get.py
@@ -264,7 +264,7 @@ def main():
         mirrors = ["http://thepiratebay.se"]
         try:
             opener = urllib2.build_opener(NoRedirection)
-            f = opener.open("http://proxybay.info/list.txt")
+            f = opener.open("https://proxybay.info/list.txt")
             if f.getcode() != 200:
                 raise Exception("The pirate bay responded with an error.")
             res = f.read()


### PR DESCRIPTION
f.getcode() returns 301 when opening "http://proxybay.info/list.txt" and the site automatically redirects to "https://proxybay.info/list.txt".
