### PR TITLE
encode strings with utf-8

### DIFF
--- a/pirate-get.py
+++ b/pirate-get.py
@@ -214,7 +214,7 @@ def main():
                 """Print with colors"""
                 try:
                     c = color_dict[kwargs.pop("color")]
-                    args = (c + str(args[0]),) + args[1:] + (colorama.Style.RESET_ALL,)
+                    args = (c + str(args[0].encode('utf-8')),) + args[1:] + (colorama.Style.RESET_ALL,)
                 except KeyError as e:
                     pass
                 except IndexError as e:


### PR DESCRIPTION
if non ascii characters are contained in any of the printed text and the `--color' option is used, the script crashes with a traceback like this:

```
Traceback (most recent call last):
  File "pirate-get.py", line 448, in <module>
    main()
  File "pirate-get.py", line 353, in main
    print_search_results()
  File "pirate-get.py", line 312, in print_search_results
    uploaded[m], torrent_name), color=cur_color)
  File "pirate-get.py", line 217, in n_print
    args = (c + str(args[0]),) + args[1:] + (colorama.Style.RESET_ALL,)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 53-54: ordinal not in range(128)
```

this patch fixes that
