### PR TITLE
fix duplicate printing when adding multiple torrents at once

### DIFF
--- a/pirate-get.py
+++ b/pirate-get.py
@@ -679,8 +679,7 @@ def main():
         url = mags[int(choice)][0]
 
         if args.transmission or config.getboolean('Misc', 'transmission'):
-            subprocess.call(transmission_command + ['-l', '--add', url], shell=False)
-            subprocess.call(transmission_command + ['-l'])
+            subprocess.call(transmission_command + ['--add', url], shell=False)
 
         elif args.command or config.get('Misc', 'openCommand'):
             command = config.get('Misc', 'openCommand')
@@ -690,6 +689,9 @@ def main():
 
         else:
             webbrowser.open(url)
+
+    if args.transmission or config.getboolean('Misc', 'transmission'):
+        subprocess.call(transmission_command + ['-l'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
because of where `transmission-remote -l` is called in the loop of adding torrents, if you add, for example, 3 torrents at once, it will print out something like this:

torrent 1 info

torrent 1 info
torrent 2 info

torrent 1 info
torrent 2 info
torrent 3 info

when really just the last block is what's needed, and is much cleaner to output.