### PR TITLE
allow ranges of values to be entered

### DIFF
--- a/pirate-get.py
+++ b/pirate-get.py
@@ -623,8 +623,19 @@ def main():
                 # Turn into list
                 l = re.sub(r'^[hdfp, ]*|[hdfp, ]*$', '', l)
                 l = re.sub('[ ,]+', ',', l)
-                l = re.sub('[^0-9,]', '', l)
-                choices = l.split(',')
+                l = re.sub('[^0-9,-]', '', l)
+                parsed_input = l.split(',')
+
+                # expand ranges
+                choices = []
+                for elem in parsed_input: # loop will generate a list of lists
+                    left, sep, right = elem.partition('-')
+                    if right:
+                        choices.append(list(range(int(left), int(right) + 1)))
+                    else:
+                        choices.append([int(left)])
+                choices = sum(choices, []) # flatten list
+                choices = [str(elem) for elem in choices] # the current code stores the choices as strings instead of ints. not sure if necessary
 
                 # Act on option, if supplied
                 print('')


### PR DESCRIPTION
This will allow input like `0-2,4,6-8` to be entered, and expands it to be `0,1,2,4,6,7,8`.

I had a question - the choices array is a list of strings currently, e.g. `['0','1','2']` as opposed to a list of ints `[0,1,2]`. From what I can tell this isn't necessary, all the code that deals with `choices` converts the elements to ints, and the program seemed to run fine without the line in this PR that converts everything to a string. I'm pretty sure that line can be removed but for now I just made it consistent with the current representation of `choices`.