### PR TITLE
Fix bug in open_command execution

### DIFF
--- a/pirate/pirate.py
+++ b/pirate/pirate.py
@@ -417,7 +417,7 @@ def pirate_main(args):
         elif args.output == 'open_command':
             cmd = parse_cmd(args.open_command, url)
             printer.print(" ".join(cmd))
-            subprocess.call(cmd)
+            subprocess.call(cmd, shell=True)
         elif args.output == 'browser_open':
             webbrowser.open(url)
 

--- a/tests/test_pirate.py
+++ b/tests/test_pirate.py
@@ -38,7 +38,7 @@ class TestPirate(unittest.TestCase):
             config = pirate.pirate.parse_config_file('')
             args = pirate.pirate.combine_configs(config, pirate.pirate.parse_args(['-0', 'term', '-C', 'blah %s']))
             pirate.pirate.pirate_main(args)
-            mock_call.assert_called_once_with(['blah', 'dn=derp'])
+            mock_call.assert_called_once_with(['blah', 'dn=derp'], shell=True)
 
     @patch('pirate.pirate.builtins.input', return_value='0')
     @patch('subprocess.call')
@@ -54,7 +54,7 @@ class TestPirate(unittest.TestCase):
             config = pirate.pirate.parse_config_file('')
             args = pirate.pirate.combine_configs(config, pirate.pirate.parse_args(['term', '-C', 'blah %s']))
             pirate.pirate.pirate_main(args)
-            mock_call.assert_called_once_with(['blah', 'dn=derp'])
+            mock_call.assert_called_once_with(['blah', 'dn=derp'], shell=True)
 
     def test_parse_torrent_command(self):
         tests = [


### PR DESCRIPTION
I wasn't able to get the open_command working when I wanted to pass a magnet URL to the open_command. With `shell=True` python opens a new shell for the executable and it works as expected.