### PR TITLE
Copying torrent magnets from the pirate-get CLI

### DIFF
--- a/pirate/pirate.py
+++ b/pirate/pirate.py
@@ -84,8 +84,8 @@ def parse_cmd(cmd, url):
 
 def parse_torrent_command(l):
     # Very permissive handling
-    # Check for any occurances or d, f, p, t, m, or q
-    cmd_code_match = re.search(r'([hdfpmtq])', l,
+    # Check for any occurances of c, d, f, p, t, m, or q
+    cmd_code_match = re.search(r'([hdfpmtqc])', l,
                                flags=re.IGNORECASE)
     if cmd_code_match:
         code = cmd_code_match.group(0).lower()
@@ -382,6 +382,7 @@ def pirate_main(args):
                     printer.print('Options:',
                                   '<links>: Download selected torrents',
                                   '[m<links>]: Save magnets as files',
+                                  '[c<links>]: Copy magnets to clipboard',
                                   '[t<links>]: Save .torrent files',
                                   '[d<links>]: Get descriptions',
                                   '[f<links>]: Get files',
@@ -399,6 +400,8 @@ def pirate_main(args):
                 elif code == 'm':
                     pirate.torrent.save_magnets(printer, choices, results,
                                                 args.save_directory)
+                elif code == 'c':
+                    pirate.torrent.copy_magnets(printer, choices, results)
                 elif code == 't':
                     pirate.torrent.save_torrents(printer, choices, results,
                                                  args.save_directory)

--- a/pirate/torrent.py
+++ b/pirate/torrent.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import gzip
+import pyperclip
 import urllib.request as request
 import urllib.parse as parse
 import urllib.error
@@ -197,3 +198,13 @@ def save_magnets(printer, chosen_links, results, folder):
         printer.print('Saved {:X} in {}'.format(info_hash, file))
         with open(file, 'w') as f:
             f.write(magnet + '\n')
+
+def copy_magnets(printer, chosen_links, results):
+    clipboard_text = ''
+    for link in chosen_links:
+        magnet = results[link]['magnet']
+        info_hash = int(re.search(r'btih:([a-f0-9]{40})', magnet).group(1), 16)
+        clipboard_text += magnet + "\n"
+        printer.print('Copying {:X} to clipboard'.format(info_hash))
+
+    pyperclip.copy(clipboard_text)

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ if __name__ == '__main__':
         },
         install_requires=['colorama>=0.3.3',
                           'beautifulsoup4>=4.4.1',
-                          'veryprettytable>=0.8.1'],
-                          'pyperclip>=1.6.2'
+                          'veryprettytable>=0.8.1',
+                          'pyperclip>=1.6.2'],
         keywords=['torrent', 'magnet', 'download', 'tpb', 'client'],
         classifiers=[
             'Topic :: Utilities',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ if __name__ == '__main__':
         install_requires=['colorama>=0.3.3',
                           'beautifulsoup4>=4.4.1',
                           'veryprettytable>=0.8.1'],
+                          'pyperclip>=1.6.2'
         keywords=['torrent', 'magnet', 'download', 'tpb', 'client'],
         classifiers=[
             'Topic :: Utilities',


### PR DESCRIPTION
I often use seedboxes, and find myself having to save a magnet to file and then copy its contents, to input a magnet link into my seedbox. To remedy this issue, I introduced the 'c' command inside pirate-get, that allows the user to copy a magnet link to the clipboard. For example, the 'c3' command would copy torrent number three into the user's clipboard.

I hope you find my pull request satisfactory. Have a great day!

 - Matteo