### PR TITLE
give more detail on error

### DIFF
--- a/pirate/torrent.py
+++ b/pirate/torrent.py
@@ -181,7 +181,7 @@ def save_torrents(printer, chosen_links, results, folder):
 
         try:
             torrent = get_torrent(info_hash)
-        except urllib.error.HTTPError:
+        except urllib.error.HTTPError as e:
             printer.print('There is no cached file for this torrent :('
                           ' \nCode: {} - {}'.format(e.code, e.reason),
                           color='ERROR')

--- a/pirate/torrent.py
+++ b/pirate/torrent.py
@@ -182,7 +182,8 @@ def save_torrents(printer, chosen_links, results, folder):
         try:
             torrent = get_torrent(info_hash)
         except urllib.error.HTTPError:
-            printer.print('There is no cached file for this torrent :(',
+            printer.print('There is no cached file for this torrent :('
+                          ' \nCode: {} - {}'.format(e.code, e.reason),
                           color='ERROR')
         else:
             open(file, 'wb').write(torrent)


### PR DESCRIPTION
Sometimes there is not possible download a torrent file (e.g.: connection error). It would be better to give more details about this error to the user.


