### PR TITLE
rename --port option to --transmission-endpoint

### DIFF
--- a/pirate/pirate.py
+++ b/pirate/pirate.py
@@ -38,7 +38,7 @@ def parse_config_file(text):
     config.set('Misc', 'openCommand', '')
     config.set('Misc', 'transmission', 'false')
     config.set('Misc', 'transmission-auth', '')
-    config.set('Misc', 'transmission-port', '')
+    config.set('Misc', 'transmission-endpoint', '')
     config.set('Misc', 'colors', 'true')
     config.set('Misc', 'mirror', pirate.data.default_mirror)
 
@@ -155,10 +155,13 @@ def parse_args(args_in):
     parser.add_argument('-t', '--transmission',
                         action='store_true',
                         help='open magnets with transmission-remote')
-    parser.add_argument('-P', '--port', dest='port',
-                        help='transmission-remote rpc port. default is 9091')
-    parser.add_argument('-A', '--auth', dest='auth',
-            help='transmission-remote rpc authentication, <user:pw>')
+    parser.add_argument('-E', '--transmission-endpoint',
+                        metavar='HOSTNAME:PORT', dest='endpoint',
+                        help='transmission-remote RPC endpoint. '
+                             'default is localhost:9091')
+    parser.add_argument('-A', '--transmission-auth',
+                        metavar='USER:PASSWORD', dest='auth',
+                        help='transmission-remote RPC authentication')
     parser.add_argument('-C', '--custom', dest='command',
                         help='open magnets with a custom command'
                               ' (%%s will be replaced with the url)')
@@ -220,16 +223,18 @@ def combine_configs(config, args):
         args.mirror = config.get('Misc', 'mirror').split()
 
     args.transmission_command = ['transmission-remote']
-    if args.port:
-        args.transmission_command.append(args.port)
-    elif config.get('Misc', 'transmission-port'):
-        args.transmission_command.append(config.get('Misc', 'transmission-port'))
+    if args.endpoint:
+        args.transmission_command.append(args.endpoint)
+    elif config.get('Misc', 'transmission-endpoint'):
+        args.transmission_command.append(
+            config.get('Misc', 'transmission-endpoint'))
     if args.auth:
         args.transmission_command.append('--auth')
         args.transmission_command.append(args.auth)
     elif config.get('Misc', 'transmission-auth'):
         args.transmission_command.append('--auth')
-        args.transmission_command.append(config.get('Misc', 'transmission-auth'))
+        args.transmission_command.append(
+            config.get('Misc', 'transmission-auth'))
 
     args.output = 'browser_open'
     if args.transmission or config.getboolean('Misc', 'transmission'):

--- a/pirate/pirate.py
+++ b/pirate/pirate.py
@@ -39,6 +39,7 @@ def parse_config_file(text):
     config.set('Misc', 'transmission', 'false')
     config.set('Misc', 'transmission-auth', '')
     config.set('Misc', 'transmission-endpoint', '')
+    config.set('Misc', 'transmission-port', '')  # for backward compatibility
     config.set('Misc', 'colors', 'true')
     config.set('Misc', 'mirror', pirate.data.default_mirror)
 
@@ -155,11 +156,11 @@ def parse_args(args_in):
     parser.add_argument('-t', '--transmission',
                         action='store_true',
                         help='open magnets with transmission-remote')
-    parser.add_argument('-E', '--transmission-endpoint',
+    parser.add_argument('-E', '--transmission-endpoint', '--port',
                         metavar='HOSTNAME:PORT', dest='endpoint',
                         help='transmission-remote RPC endpoint. '
                              'default is localhost:9091')
-    parser.add_argument('-A', '--transmission-auth',
+    parser.add_argument('-A', '--transmission-auth', '--auth',
                         metavar='USER:PASSWORD', dest='auth',
                         help='transmission-remote RPC authentication')
     parser.add_argument('-C', '--custom', dest='command',
@@ -228,6 +229,10 @@ def combine_configs(config, args):
     elif config.get('Misc', 'transmission-endpoint'):
         args.transmission_command.append(
             config.get('Misc', 'transmission-endpoint'))
+    # for backward compatibility
+    elif config.get('Misc', 'transmission-port'):
+        args.transmission_command.append(
+            config.get('Misc', 'transmission-port'))
     if args.auth:
         args.transmission_command.append('--auth')
         args.transmission_command.append(args.auth)

--- a/tests/test_pirate.py
+++ b/tests/test_pirate.py
@@ -130,7 +130,7 @@ class TestPirate(unittest.TestCase):
             ('', ['term'], {'action': 'search', 'source': 'tpb'}),
             ('', ['-L', 'filename', 'term'], {'action': 'search', 'source': 'local_tpb', 'database': 'filename'}),
             ('', ['term', '-S', 'dir'], {'action': 'search', 'save_directory': 'dir'}),
-            ('', ['-P', '1337'], {'transmission_command': ['transmission-remote', '1337']}),
+            ('', ['-E', 'localhost:1337'], {'transmission_command': ['transmission-remote', 'localhost:1337']}),
             ('', ['term'], {'output': 'browser_open'}),
             ('', ['term', '-t'], {'output': 'transmission'}),
             ('', ['term', '--save-magnets'], {'output': 'save_magnet_files'}),


### PR DESCRIPTION
This is a fix for #127. The current `--port/-P` options actually can specify both hostname and port (and endpoint) but it's not clear from the pirate-get help.