### PR TITLE
handle cookies for tpb http requests

### DIFF
--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -93,8 +93,12 @@ class TestPrint(unittest.TestCase):
             read = MagicMock(return_value='<html><div class="nfo"><pre>stuff <a href="href">link</a></pre></div></html>'.encode('utf8'))
             info = MagicMock()
         response_obj = MockResponse()
+        class MockOpener():
+            open = MagicMock(return_value=response_obj)
+            add_handler = MagicMock()
+        opener_obj = MockOpener()
         with patch('urllib.request.Request', return_value=request_obj) as request:
-            with patch('urllib.request.urlopen', return_value=response_obj) as urlopen:
+            with patch('urllib.request.OpenerDirector', return_value=opener_obj) as opener:
                 printer.descriptions([0], [{'id': '1', 'magnet': 'dn=name'}], 'example.com')
                 printer.print.assert_has_calls([call('Description for "name":', color='zebra_1'),call('stuff [link](href)', color='zebra_0')])
 
@@ -108,8 +112,12 @@ class TestPrint(unittest.TestCase):
             read = MagicMock(return_value='<html><tr><td align="left">1.</td><td align="right">filename</tr></html>'.encode('utf8'))
             info = MagicMock()
         response_obj = MockResponse()
+        class MockOpener():
+            open = MagicMock(return_value=response_obj)
+            add_handler = MagicMock()
+        opener_obj = MockOpener()
         with patch('urllib.request.Request', return_value=request_obj) as request:
-            with patch('urllib.request.urlopen', return_value=response_obj) as urlopen:
+            with patch('urllib.request.OpenerDirector', return_value=opener_obj) as opener:
                 printer.file_lists([0], [{'id': '1', 'magnet': 'dn=name'}], 'example.com')
                 printer.print.assert_has_calls([call('Files in "name":', color='zebra_1'),call('         1.  filename', color='zebra_0')])
 

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import unittest
 from unittest.mock import patch, call, MagicMock
 
@@ -6,6 +7,10 @@ from pirate.print import Printer
 
 
 class TestPrint(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # needed to display the results table
+        os.environ['COLUMNS'] = '80'
 
     def test_print_results_remote(self):
         class MockTable:

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -124,14 +124,18 @@ class TestTorrent(unittest.TestCase):
             add_header = mock.MagicMock()
         request_obj = MockRequest()
         class MockResponse():
-            read = mock.MagicMock(return_value='<html>No hits. Try adding an asterisk in you search phrase.</html>'.encode('utf8'))
+            read = mock.MagicMock(return_value=b'<html>No hits. Try adding an asterisk in you search phrase.</html>')
             info = mock.MagicMock()
         response_obj = MockResponse()
+        class MockOpener():
+            open = mock.MagicMock(return_value=response_obj)
+            add_handler = mock.MagicMock()
+        opener_obj = MockOpener()
         with patch('urllib.request.Request', return_value=request_obj) as request:
-            with patch('urllib.request.urlopen', return_value=response_obj) as urlopen:
+            with patch('urllib.request.OpenerDirector', return_value=opener_obj) as opener:
                 res = pirate.torrent.remote(MagicMock(Printer), 1, 100, 10, 'browse', [], 'http://example.com')
                 request.assert_called_once_with('http://example.com/browse/100/0/10', headers=pirate.data.default_headers)
-                urlopen.assert_called_once_with(request_obj, timeout=pirate.data.default_timeout)
+                opener_obj.open.assert_called_once_with(request_obj, timeout=pirate.data.default_timeout)
                 self.assertEqual(res, [])
 
 if __name__ == '__main__':


### PR DESCRIPTION
The pirate bay (or a hoster in between) added a mechanism to rate-limit requests that forces us to handle cookies. This should fix #131.