### PR TITLE
Fixed error handling

### DIFF
--- a/pirate/torrent.py
+++ b/pirate/torrent.py
@@ -146,7 +146,7 @@ def find_api(mirror, timeout):
             f = request.urlopen(req, timeout=timeout)
             if f.info().get_content_type() == 'application/json':
                 return mirror + path
-        except urllib.error.URLError as e:
+        except urllib.error.HTTPError as e:
             res = e.fp.read().decode()
             if e.code == 503 and 'cf-browser-verification' in res:
                 raise IOError('Cloudflare protected')


### PR DESCRIPTION
On my computer it's failing on the first request to https://thepiratebay.org/ with a timeout exception. I think the properties this code is handling need an HTTPError according to the doc https://docs.python.org/3/library/urllib.error.html#urllib.error.HTTPError